### PR TITLE
fix container volume mount

### DIFF
--- a/test/e2e_node/init_containers_test.go
+++ b/test/e2e_node/init_containers_test.go
@@ -563,7 +563,8 @@ func preparePod(pod *v1.Pod) {
 		},
 	}
 
-	for _, c := range pod.Spec.Containers {
+	for i := range pod.Spec.Containers {
+		c := &pod.Spec.Containers[i]
 		c.Resources = defaultResourceRequirements
 		c.VolumeMounts = []v1.VolumeMount{
 			{
@@ -572,7 +573,8 @@ func preparePod(pod *v1.Pod) {
 			},
 		}
 	}
-	for _, c := range pod.Spec.InitContainers {
+	for i := range pod.Spec.InitContainers {
+		c := &pod.Spec.InitContainers[i]
 		c.Resources = defaultResourceRequirements
 		c.VolumeMounts = []v1.VolumeMount{
 			{


### PR DESCRIPTION
Volumes aren't getting attached to the containers, so the log isn't persistent.  With this change, the log looks like:

```
  1678456913 83037.18 regular-1 Starting
  1678456913 83037.18 regular-1 Delaying 1
  1678456914 83038.18 regular-1 Exiting
  1678456914 83038.30 regular-1 Starting
  1678456914 83038.30 regular-1 Delaying 1
  1678456915 83039.30 regular-1 Exiting
  1678456929 83053.24 regular-1 Starting
  1678456929 83053.24 regular-1 Delaying 1
  1678456930 83054.24 regular-1 Exiting
```