### PR TITLE
sidecar: Complete e2e tests

### DIFF
--- a/test/e2e_node/containers_lifecycle_test.go
+++ b/test/e2e_node/containers_lifecycle_test.go
@@ -820,12 +820,63 @@ var _ = SIGDescribe("[NodeAlphaFeature:SidecarContainers] Containers Lifecycle "
 	ginkgo.When("using a sidecar in a Pod with restartPolicy=OnFailure", ginkgo.Ordered, func() {
 		// this test case the same as for restartPolicy=Never
 		ginkgo.When("a sidecar runs continuously", func() {
-			ginkgo.It("should complete a Pod successfully and produce log", func() {})
-			ginkgo.It("should not restart a sidecar", func() {})
-			ginkgo.It("should run a regular container to completion", func() {})
+
+			sidecar1 := "sidecar-1"
+			regular1 := "regular-1"
+
+			podSpec := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sidecar-container-run-continuously",
+				},
+				Spec: v1.PodSpec{
+					RestartPolicy: v1.RestartPolicyOnFailure,
+					InitContainers: []v1.Container{
+						{
+							Name:  sidecar1,
+							Image: busyboxImage,
+							Command: ExecCommand(sidecar1, execCommand{
+								Delay:    600,
+								ExitCode: 0,
+							}),
+							RestartPolicy: &containerRestartPolicyAlways,
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:  regular1,
+							Image: busyboxImage,
+							Command: ExecCommand(regular1, execCommand{
+								Delay:    1,
+								ExitCode: 0,
+							}),
+						},
+					},
+				},
+			}
+
+			preparePod(podSpec)
+			var results containerOutputList
+
+			ginkgo.It("should complete a Pod successfully and produce log", func() {
+				client := e2epod.NewPodClient(f)
+				podSpec = client.Create(context.TODO(), podSpec)
+
+				err := e2epod.WaitTimeoutForPodNoLongerRunningInNamespace(context.TODO(), f.ClientSet, podSpec.Name, podSpec.Namespace, 5*time.Minute)
+				framework.ExpectNoError(err)
+
+				podSpec, err := client.Get(context.TODO(), podSpec.Name, metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				results = parseOutput(podSpec)
+			})
+			ginkgo.It("should not restart a sidecar", func() {
+				framework.ExpectNoError(results.DoesntStartAfter(sidecar1, regular1))
+			})
+			ginkgo.It("should run a regular container to completion", func() {
+				framework.ExpectNoError(results.Exits(regular1))
+			})
 		})
 
-		ginkgo.When("a sidecar fails to start because of a bad image", ginkgo.Ordered, func() {
+		ginkgo.When("[NOT WORKING] a sidecar fails to start because of a bad image", ginkgo.Ordered, func() {
 			ginkgo.It("should continuously run Pod keeping it Pending", func() { /* check the restartCount > 5 */ })
 			// this is different from restartPolicy=Never
 			ginkgo.It("should restart a sidecar", func() {})
@@ -835,34 +886,294 @@ var _ = SIGDescribe("[NodeAlphaFeature:SidecarContainers] Containers Lifecycle "
 		// TODO: add a test case similar to one above, but with startup probe never succeeding
 
 		// this test case the same as for restartPolicy=Never
-		ginkgo.When("a sidecar starts and exists with exit code 0 continuously", ginkgo.Ordered, func() {
+		ginkgo.When("a sidecar starts and exits with exit code 0 continuously", ginkgo.Ordered, func() {
+
+			sidecar1 := "sidecar-1"
+			init1 := "init-1"
+			regular1 := "regular-1"
+
+			podSpec := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sidecar-container-exit-0-continuously",
+				},
+				Spec: v1.PodSpec{
+					RestartPolicy: v1.RestartPolicyOnFailure,
+					InitContainers: []v1.Container{
+						{
+							Name:  sidecar1,
+							Image: busyboxImage,
+							Command: ExecCommand(sidecar1, execCommand{
+								Delay:    1,
+								ExitCode: 0,
+							}),
+							RestartPolicy: &containerRestartPolicyAlways,
+						},
+						{
+							Name:  init1,
+							Image: busyboxImage,
+							Command: ExecCommand(init1, execCommand{
+								Delay:    5,
+								ExitCode: 0,
+							}),
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:  regular1,
+							Image: busyboxImage,
+							Command: ExecCommand(regular1, execCommand{
+								Delay:    60,
+								ExitCode: 0,
+							}),
+						},
+					},
+				},
+			}
+
+			preparePod(podSpec)
+			var results containerOutputList
+
 			// TODO: pod with sidecar, init, regular container
-			ginkgo.It("should complete a Pod successfully and produce log", func() {})
-			ginkgo.It("should restart a sidecar before the regular container started", func() {})
-			ginkgo.It("should restart a sidecar after the regular container started", func() {})
-			ginkgo.It("should run a regular container to completion", func() {})
+			ginkgo.It("should complete a Pod successfully and produce log", func() {
+				client := e2epod.NewPodClient(f)
+				podSpec = client.Create(context.TODO(), podSpec)
+
+				err := e2epod.WaitTimeoutForPodNoLongerRunningInNamespace(context.TODO(), f.ClientSet, podSpec.Name, podSpec.Namespace, 5*time.Minute)
+				framework.ExpectNoError(err)
+
+				podSpec, err := client.Get(context.TODO(), podSpec.Name, metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				results = parseOutput(podSpec)
+			})
+			ginkgo.It("should restart a sidecar before the regular container started", func() {
+				framework.ExpectNoError(results.StartsBefore(sidecar1, regular1))
+			})
+			ginkgo.It("should restart a sidecar after the regular container started", func() {
+				framework.ExpectNoError(results.StartsBefore(regular1, sidecar1))
+			})
+			ginkgo.It("should run a regular container to completion", func() {
+				framework.ExpectNoError(results.Exits(regular1))
+			})
 		})
 
 		// this test case the same as for restartPolicy=Never
-		ginkgo.When("a sidecar starts and exists with exit code 1 continuously", ginkgo.Ordered, func() {
+		ginkgo.When("a sidecar starts and exits with exit code 1 continuously", ginkgo.Ordered, func() {
 			// TODO: pod with sidecar, init, regular container
-			ginkgo.It("should complete a Pod successfully and produce log", func() {})
-			ginkgo.It("should restart a sidecar before the regular container started", func() {})
-			ginkgo.It("should restart a sidecar after the regular container started", func() {})
-			ginkgo.It("should run a regular container to completion", func() {})
+
+			sidecar1 := "sidecar-1"
+			init1 := "init-1"
+			regular1 := "regular-1"
+
+			podSpec := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sidecar-container-exit-1-continuously",
+				},
+				Spec: v1.PodSpec{
+					RestartPolicy: v1.RestartPolicyOnFailure,
+					InitContainers: []v1.Container{
+						{
+							Name:  sidecar1,
+							Image: busyboxImage,
+							Command: ExecCommand(sidecar1, execCommand{
+								Delay:    1,
+								ExitCode: 1,
+							}),
+							RestartPolicy: &containerRestartPolicyAlways,
+						},
+						{
+							Name:  init1,
+							Image: busyboxImage,
+							Command: ExecCommand(init1, execCommand{
+								Delay:    5,
+								ExitCode: 0,
+							}),
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:  regular1,
+							Image: busyboxImage,
+							Command: ExecCommand(regular1, execCommand{
+								Delay:    60,
+								ExitCode: 0,
+							}),
+						},
+					},
+				},
+			}
+
+			preparePod(podSpec)
+			var results containerOutputList
+
+			ginkgo.It("should complete a Pod successfully and produce log", func() {
+				client := e2epod.NewPodClient(f)
+				podSpec = client.Create(context.TODO(), podSpec)
+
+				err := e2epod.WaitTimeoutForPodNoLongerRunningInNamespace(context.TODO(), f.ClientSet, podSpec.Name, podSpec.Namespace, 5*time.Minute)
+				framework.ExpectNoError(err)
+
+				podSpec, err := client.Get(context.TODO(), podSpec.Name, metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				results = parseOutput(podSpec)
+			})
+			ginkgo.It("should restart a sidecar before the regular container started", func() {
+				framework.ExpectNoError(results.StartsBefore(sidecar1, regular1))
+			})
+			ginkgo.It("should restart a sidecar after the regular container started", func() {
+				framework.ExpectNoError(results.StartsBefore(regular1, sidecar1))
+			})
+			ginkgo.It("should run a regular container to completion", func() {
+				framework.ExpectNoError(results.Exits(regular1))
+			})
 		})
 
 		ginkgo.When("an Init container before sidecar continuously fails", ginkgo.Ordered, func() {
-			ginkgo.It("should continuously run Pod keeping it Pending", func() { /* check the restartCount > 5 */ })
-			ginkgo.It("should have Init container restartCount greater than 0", func() {})
-			ginkgo.It("should not start sidecar", func() {})
+
+			init1 := "init-1"
+			sidecar1 := "sidecar-1"
+			regular1 := "regular-1"
+
+			podSpec := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "init-container-fails-before-sidecar-starts",
+				},
+				Spec: v1.PodSpec{
+					RestartPolicy: v1.RestartPolicyOnFailure,
+					InitContainers: []v1.Container{
+						{
+							Name:  init1,
+							Image: busyboxImage,
+							Command: ExecCommand(init1, execCommand{
+								Delay:    1,
+								ExitCode: 1,
+							}),
+						},
+						{
+							Name:  sidecar1,
+							Image: busyboxImage,
+							Command: ExecCommand(sidecar1, execCommand{
+								Delay:    600,
+								ExitCode: 0,
+							}),
+							RestartPolicy: &containerRestartPolicyAlways,
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:  regular1,
+							Image: busyboxImage,
+							Command: ExecCommand(regular1, execCommand{
+								Delay:    600,
+								ExitCode: 0,
+							}),
+						},
+					},
+				},
+			}
+
+			preparePod(podSpec)
+			var results containerOutputList
+
+			ginkgo.It("should continuously run Pod keeping it Pending", func() { /* check the restartCount > 5 */
+				client := e2epod.NewPodClient(f)
+				podSpec = client.Create(context.TODO(), podSpec)
+
+				e2epod.WaitForPodCondition(context.TODO(), f.ClientSet, podSpec.Namespace, podSpec.Name, "pending and restarting 5 times", 5*time.Minute, func(pod *v1.Pod) (bool, error) {
+					if pod.Status.Phase != v1.PodPending {
+						return false, fmt.Errorf("pod should be in pending phase")
+					}
+					if len(pod.Status.InitContainerStatuses) < 1 {
+						return false, nil
+					}
+					containerStatus := pod.Status.InitContainerStatuses[0]
+					return containerStatus.RestartCount > 5, nil
+				})
+
+				podSpec, err := client.Get(context.TODO(), podSpec.Name, metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				results = parseOutput(podSpec)
+			})
+			ginkgo.It("should have Init container restartCount greater than 0", func() {
+				framework.ExpectNoError(results.HasRestarted(init1))
+			})
+			ginkgo.It("should not start sidecar", func() {
+				framework.ExpectNoError(results.DoesntStart(sidecar1))
+			})
 		})
 
 		ginkgo.When("an Init container after sidecar fails", ginkgo.Ordered, func() {
-			ginkgo.It("should continuously run Pod keeping it Pending", func() { /* check the restartCount > 5 */ })
-			ginkgo.It("should have Init container restartCount greater than 0", func() {})
+
+			init1 := "init-1"
+			sidecar1 := "sidecar-1"
+			regular1 := "regular-1"
+
+			podSpec := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "sidecar-container-fails-before-init-container",
+				},
+				Spec: v1.PodSpec{
+					RestartPolicy: v1.RestartPolicyOnFailure,
+					InitContainers: []v1.Container{
+						{
+							Name:  sidecar1,
+							Image: busyboxImage,
+							Command: ExecCommand(sidecar1, execCommand{
+								Delay:    1,
+								ExitCode: 1,
+							}),
+							RestartPolicy: &containerRestartPolicyAlways,
+						},
+						{
+							Name:  init1,
+							Image: busyboxImage,
+							Command: ExecCommand(init1, execCommand{
+								Delay:    1,
+								ExitCode: 1,
+							}),
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:  regular1,
+							Image: busyboxImage,
+							Command: ExecCommand(regular1, execCommand{
+								Delay:    600,
+								ExitCode: 0,
+							}),
+						},
+					},
+				},
+			}
+
+			preparePod(podSpec)
+			var results containerOutputList
+
+			ginkgo.It("should continuously run Pod keeping it Pending", func() { /* check the restartCount > 5 */
+				client := e2epod.NewPodClient(f)
+				podSpec = client.Create(context.TODO(), podSpec)
+
+				e2epod.WaitForPodCondition(context.TODO(), f.ClientSet, podSpec.Namespace, podSpec.Name, "pending and restarting 5 times", 5*time.Minute, func(pod *v1.Pod) (bool, error) {
+					if pod.Status.Phase != v1.PodPending {
+						return false, fmt.Errorf("pod should be in pending phase")
+					}
+					if len(pod.Status.InitContainerStatuses) < 1 {
+						return false, nil
+					}
+					containerStatus := pod.Status.InitContainerStatuses[0]
+					return containerStatus.RestartCount > 5, nil
+				})
+
+				podSpec, err := client.Get(context.TODO(), podSpec.Name, metav1.GetOptions{})
+				framework.ExpectNoError(err)
+				results = parseOutput(podSpec)
+			})
+			ginkgo.It("should have Init container restartCount greater than 0", func() {
+				framework.ExpectNoError(results.HasRestarted(init1))
+			})
 			// TODO: how will we be able to test it if sidecar will never fail and there will be no termination log? Or will be?
-			ginkgo.It("should be running sidecar and a failed Init container in parallel", func() {})
+			ginkgo.It("should be running sidecar and a failed Init container in parallel", func() {
+				framework.ExpectNoError(results.RunTogether(sidecar1, init1))
+			})
 			// TODO: check preStop hooks when they are enabled
 		})
 	})
@@ -875,7 +1186,7 @@ var _ = SIGDescribe("[NodeAlphaFeature:SidecarContainers] Containers Lifecycle "
 
 			podSpec := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "sidecar-containers-with-restartpolicy-always",
+					Name: "sidecar-container-run-continuously",
 				},
 				Spec: v1.PodSpec{
 					RestartPolicy: v1.RestartPolicyAlways,
@@ -1027,7 +1338,7 @@ var _ = SIGDescribe("[NodeAlphaFeature:SidecarContainers] Containers Lifecycle "
 							Name:  regular1,
 							Image: busyboxImage,
 							Command: ExecCommand(regular1, execCommand{
-								Delay:    1,
+								Delay:    60,
 								ExitCode: 0,
 							}),
 						},
@@ -1043,7 +1354,7 @@ var _ = SIGDescribe("[NodeAlphaFeature:SidecarContainers] Containers Lifecycle "
 				client := e2epod.NewPodClient(f)
 				podSpec = client.Create(context.TODO(), podSpec)
 
-				err := WaitForPodContainerRestartCount(context.TODO(), f.ClientSet, podSpec.Namespace, podSpec.Name, 0, 3, 2*time.Minute)
+				err := WaitForPodContainerRestartCount(context.TODO(), f.ClientSet, podSpec.Namespace, podSpec.Name, 0, 1, 2*time.Minute)
 				framework.ExpectNoError(err)
 
 				podSpec, err := client.Get(context.TODO(), podSpec.Name, metav1.GetOptions{})
@@ -1099,7 +1410,7 @@ var _ = SIGDescribe("[NodeAlphaFeature:SidecarContainers] Containers Lifecycle "
 							Name:  regular1,
 							Image: busyboxImage,
 							Command: ExecCommand(regular1, execCommand{
-								Delay:    1,
+								Delay:    60,
 								ExitCode: 0,
 							}),
 						},
@@ -1114,7 +1425,7 @@ var _ = SIGDescribe("[NodeAlphaFeature:SidecarContainers] Containers Lifecycle "
 				client := e2epod.NewPodClient(f)
 				podSpec = client.Create(context.TODO(), podSpec)
 
-				err := WaitForPodContainerRestartCount(context.TODO(), f.ClientSet, podSpec.Namespace, podSpec.Name, 0, 3, 2*time.Minute)
+				err := WaitForPodContainerRestartCount(context.TODO(), f.ClientSet, podSpec.Namespace, podSpec.Name, 0, 1, 2*time.Minute)
 				framework.ExpectNoError(err)
 
 				podSpec, err := client.Get(context.TODO(), podSpec.Name, metav1.GetOptions{})

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -69,6 +69,9 @@ var (
 	e2es *services.E2EServices
 	// featureGates is a map of feature names to bools that enable or disable alpha/experimental features.
 	featureGates map[string]bool
+	// serviceFeatureGates is a map of feature names to bools that enable or
+	// disable alpha/experimental features for API service.
+	serviceFeatureGates map[string]bool
 
 	// TODO(random-liu): Change the following modes to sub-command.
 	runServicesMode    = flag.Bool("run-services-mode", false, "If true, only run services (etcd, apiserver) in current process, and not run test.")
@@ -100,6 +103,7 @@ func registerNodeFlags(flags *flag.FlagSet) {
 	flag.Var(cliflag.NewMapStringString(&framework.TestContext.RuntimeConfig), "runtime-config", "The runtime configuration used on node e2e tests.")
 	flags.BoolVar(&framework.TestContext.RequireDevices, "require-devices", false, "If true, require device plugins to be installed in the running environment.")
 	flags.Var(cliflag.NewMapStringBool(&featureGates), "feature-gates", "A set of key=value pairs that describe feature gates for alpha/experimental features.")
+	flags.Var(cliflag.NewMapStringBool(&serviceFeatureGates), "service-feature-gates", "A set of key=value pairs that describe feature gates for alpha/experimental features for API service.")
 }
 
 func init() {
@@ -131,8 +135,8 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	if err := services.SetFeatureGatesForInProcessComponents(featureGates); err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: initialize process feature gates: %v", err)
+	if err := services.SetFeatureGatesForInProcessComponents(serviceFeatureGates); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: initialize process feature gates for API service: %v", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
I just try completing this e2e test. (feel free to ignore or patch this)

- [x] `When("using a sidecar in a Pod with restartPolicy=Never"`)
- [x] `When("using a sidecar in a Pod with restartPolicy=OnFailure"`)
- [x] `When("using a sidecar in a Pod with restartPolicy=Always"`)
