### PR TITLE
sidecar: Fix e2e tests

### DIFF
--- a/test/e2e_node/containers_lifecycle_test.go
+++ b/test/e2e_node/containers_lifecycle_test.go
@@ -589,7 +589,7 @@ func parseOutput(pod *v1.Pod) containerOutputList {
 	statuses = append(statuses, pod.Status.ContainerStatuses...)
 	var buf bytes.Buffer
 	for _, cs := range statuses {
-		if cs.State.Terminated != nil {
+		if cs.State.Terminated != nil && cs.State.Terminated.Reason != "ContainerStatusUnknown" {
 			buf.WriteString(cs.State.Terminated.Message)
 		} else if cs.LastTerminationState.Terminated != nil {
 			buf.WriteString(cs.LastTerminationState.Terminated.Message)
@@ -1496,11 +1496,11 @@ var _ = SIGDescribe("[NodeAlphaFeature:SidecarContainers] Containers Lifecycle "
 			preparePod(podSpec)
 			var results containerOutputList
 
-			ginkgo.It("should continuously run Pod keeping it Pending", func() { /* check the restartCount > 5 */
+			ginkgo.It("should continuously run Pod keeping it Pending", func() {
 				client := e2epod.NewPodClient(f)
 				podSpec = client.Create(context.TODO(), podSpec)
 
-				e2epod.WaitForPodCondition(context.TODO(), f.ClientSet, podSpec.Namespace, podSpec.Name, "pending and restarting 5 times", 5*time.Minute, func(pod *v1.Pod) (bool, error) {
+				err := e2epod.WaitForPodCondition(context.TODO(), f.ClientSet, podSpec.Namespace, podSpec.Name, "pending and restarting 3 times", 5*time.Minute, func(pod *v1.Pod) (bool, error) {
 					if pod.Status.Phase != v1.PodPending {
 						return false, fmt.Errorf("pod should be in pending phase")
 					}
@@ -1508,8 +1508,9 @@ var _ = SIGDescribe("[NodeAlphaFeature:SidecarContainers] Containers Lifecycle "
 						return false, nil
 					}
 					containerStatus := pod.Status.InitContainerStatuses[0]
-					return containerStatus.RestartCount > 5, nil
+					return containerStatus.RestartCount >= 3, nil
 				})
+				framework.ExpectNoError(err)
 
 				podSpec, err := client.Get(context.TODO(), podSpec.Name, metav1.GetOptions{})
 				framework.ExpectNoError(err)
@@ -1570,11 +1571,11 @@ var _ = SIGDescribe("[NodeAlphaFeature:SidecarContainers] Containers Lifecycle "
 			preparePod(podSpec)
 			var results containerOutputList
 
-			ginkgo.It("should continuously run Pod keeping it Pending", func() { /* check the restartCount > 5 */
+			ginkgo.It("should continuously run Pod keeping it Pending", func() {
 				client := e2epod.NewPodClient(f)
 				podSpec = client.Create(context.TODO(), podSpec)
 
-				e2epod.WaitForPodCondition(context.TODO(), f.ClientSet, podSpec.Namespace, podSpec.Name, "pending and restarting 5 times", 5*time.Minute, func(pod *v1.Pod) (bool, error) {
+				err := e2epod.WaitForPodCondition(context.TODO(), f.ClientSet, podSpec.Namespace, podSpec.Name, "pending and restarting 3 times", 5*time.Minute, func(pod *v1.Pod) (bool, error) {
 					if pod.Status.Phase != v1.PodPending {
 						return false, fmt.Errorf("pod should be in pending phase")
 					}
@@ -1582,8 +1583,9 @@ var _ = SIGDescribe("[NodeAlphaFeature:SidecarContainers] Containers Lifecycle "
 						return false, nil
 					}
 					containerStatus := pod.Status.InitContainerStatuses[0]
-					return containerStatus.RestartCount > 5, nil
+					return containerStatus.RestartCount >= 3, nil
 				})
+				framework.ExpectNoError(err)
 
 				podSpec, err := client.Get(context.TODO(), podSpec.Name, metav1.GetOptions{})
 				framework.ExpectNoError(err)
@@ -1910,11 +1912,11 @@ var _ = SIGDescribe("[NodeAlphaFeature:SidecarContainers] Containers Lifecycle "
 			preparePod(podSpec)
 			var results containerOutputList
 
-			ginkgo.It("should continuously run Pod keeping it Pending", func() { /* check the restartCount > 5 */
+			ginkgo.It("should continuously run Pod keeping it Pending", func() {
 				client := e2epod.NewPodClient(f)
 				podSpec = client.Create(context.TODO(), podSpec)
 
-				e2epod.WaitForPodCondition(context.TODO(), f.ClientSet, podSpec.Namespace, podSpec.Name, "pending and restarting 5 times", 5*time.Minute, func(pod *v1.Pod) (bool, error) {
+				err := e2epod.WaitForPodCondition(context.TODO(), f.ClientSet, podSpec.Namespace, podSpec.Name, "pending and restarting 3 times", 5*time.Minute, func(pod *v1.Pod) (bool, error) {
 					if pod.Status.Phase != v1.PodPending {
 						return false, fmt.Errorf("pod should be in pending phase")
 					}
@@ -1922,8 +1924,9 @@ var _ = SIGDescribe("[NodeAlphaFeature:SidecarContainers] Containers Lifecycle "
 						return false, nil
 					}
 					containerStatus := pod.Status.InitContainerStatuses[0]
-					return containerStatus.RestartCount > 5, nil
+					return containerStatus.RestartCount >= 3, nil
 				})
+				framework.ExpectNoError(err)
 
 				podSpec, err := client.Get(context.TODO(), podSpec.Name, metav1.GetOptions{})
 				framework.ExpectNoError(err)
@@ -1984,11 +1987,11 @@ var _ = SIGDescribe("[NodeAlphaFeature:SidecarContainers] Containers Lifecycle "
 			preparePod(podSpec)
 			var results containerOutputList
 
-			ginkgo.It("should continuously run Pod keeping it Pending", func() { /* check the restartCount > 5 */
+			ginkgo.It("should continuously run Pod keeping it Pending", func() {
 				client := e2epod.NewPodClient(f)
 				podSpec = client.Create(context.TODO(), podSpec)
 
-				e2epod.WaitForPodCondition(context.TODO(), f.ClientSet, podSpec.Namespace, podSpec.Name, "pending and restarting 5 times", 5*time.Minute, func(pod *v1.Pod) (bool, error) {
+				err := e2epod.WaitForPodCondition(context.TODO(), f.ClientSet, podSpec.Namespace, podSpec.Name, "pending and restarting 3 times", 5*time.Minute, func(pod *v1.Pod) (bool, error) {
 					if pod.Status.Phase != v1.PodPending {
 						return false, fmt.Errorf("pod should be in pending phase")
 					}
@@ -1996,8 +1999,9 @@ var _ = SIGDescribe("[NodeAlphaFeature:SidecarContainers] Containers Lifecycle "
 						return false, nil
 					}
 					containerStatus := pod.Status.InitContainerStatuses[0]
-					return containerStatus.RestartCount > 5, nil
+					return containerStatus.RestartCount >= 3, nil
 				})
+				framework.ExpectNoError(err)
 
 				podSpec, err := client.Get(context.TODO(), podSpec.Name, metav1.GetOptions{})
 				framework.ExpectNoError(err)


### PR DESCRIPTION
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/116429/pull-kubernetes-node-e2e-containerd-sidecar-containers/1640524710724767744/
```
E2eNode Suite: [It] [sig-node] [NodeAlphaFeature:SidecarContainers] Containers Lifecycle when using a sidecar in a Pod with restartPolicy=OnFailure when a sidecar starts and exits with exit code 1 continuously should complete a Pod successfully and produce log expand_less | 1m12s
-- | --
{ failed [FAILED] strconv.ParseInt: parsing "The": invalid syntax In [It] at: test/e2e_node/containers_lifecycle_test.go:608 @ 03/28/23 01:40:38.961 }
```

Currently, the e2e tests are failing intermittently as the kubelet is overwriting the termination log when the sidecar container remains in a non-terminated state.

See [here](https://github.com/kubernetes/kubernetes/blob/c3e7eca7fd38454200819b60e58144d5727f1bbc/pkg/kubelet/status/status_manager.go#L436-L441).

This makes `parseOutput` read the last termination log and reduces the test time.

I'll self-merge it as this is a noncritical fix.